### PR TITLE
Fix Potential NAN bug

### DIFF
--- a/Demo/Mnist.py
+++ b/Demo/Mnist.py
@@ -83,8 +83,8 @@ y = tf.nn.softmax(tf.matmul(h_fc1,w_fc2)+b_fc1)
 
 
 # Loss
-cross_entropy = -tf.reduce_sum(y_label * tf.log(y))
-
+# cross_entropy = -tf.reduce_sum(y_label * tf.log(y))
+cross_entropy = -tf.reduce_sum(y_label * tf.log(y + 1e-7))
 
 train = tf.train.AdamOptimizer(1e-4).minimize(cross_entropy)
 


### PR DESCRIPTION
[Potential NAN bug] Loss may become NAN during training



Hello~

Thank you very much for sharing the code!

I try to use my own data set ( with the same shape as mnist) in  code. After some iterations, it is found that the training loss becomes NAN. After carefully checking the code, I found that the following code may trigger NAN in loss:

In `Tensorflow_gesture/Demo/Mnist.py`

```python
cross_entropy = -tf.reduce_sum(y_label * tf.log(y))
```

If  y contains 0 (output of softmax ), the result of `tf.log(y)` is `inf` because `log(0)` is illegal . And this may cause the result of loss to become NAN.

It could be fixed by making the following changes:

```python
cross_entropy = -tf.reduce_sum(y_label * tf.log(y + 1e-7))
```

or

```python
cross_entropy = -tf.reduce_sum(y_label * tf.log(tf.clip_by_value(y,1e-7,1.0)))
```

Hope to hear from you ~

Thanks in advance!  : ) 

